### PR TITLE
fix(deps): update nltk to 3.9.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "ml-dtypes==0.2.0",
     "msgpack==1.0.8",
     "networkx==3.3",
-    "nltk==3.2.4",
+    "nltk==3.9.4",
     "numba==0.60.0",
     "numexpr==2.10.0",
     "numpy==1.24.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ mdurl==0.1.2
 ml-dtypes==0.2.0
 msgpack==1.0.8
 networkx==3.3
-nltk==3.2.4
+nltk==3.9.4
 numba==0.60.0
 numexpr==2.10.0
 numpy==1.24.3


### PR DESCRIPTION
## Security Fix

Updates **nltk** from `3.2.4` to `3.9.4` to resolve **24 Dependabot alerts** (critical severity).

### Resolved vulnerabilities:
- CVE-2025-14009, CVE-2026-0846, CVE-2026-0847, CVE-2026-12061, CVE-2026-12072
- CVE-2026-12074, CVE-2026-12075, CVE-2026-33230, CVE-2026-33231, CVE-2026-33236
- CVE-2026-54293

Including: Path traversal (arbitrary file read/overwrite), DNS-rebinding SSRF bypass, ReDoS, unbounded recursion DoS.

### Impact assessment:
- `nltk` is not directly imported anywhere in the codebase
- This is a safe version bump with no breaking changes expected

Resolves Dependabot alerts.