### PR TITLE
fix: keep features when importance filter would drop all

### DIFF
--- a/src/automotive_feature_engineering/feature_selection.py
+++ b/src/automotive_feature_engineering/feature_selection.py
@@ -550,6 +550,15 @@ class FeatureSelection:
         )
         drop_cols_fi = df_train_features.columns[~keep_cols_fi]
         drop_cols_fi = [col for col in drop_cols_fi if col != ""]
+        # If every feature is below the threshold (common with uniform /
+        # one-hot CAN-like signals), keep all features instead of emptying
+        # the dataset and failing later in transform.
+        if len(drop_cols_fi) == len(df_train_features.columns):
+            print(
+                "Warning: no features passed the importance threshold; "
+                "keeping all features."
+            )
+            return []
         return drop_cols_fi
 
     ##########################################
@@ -567,8 +576,17 @@ class FeatureSelection:
         - pd.DataFrame: Modified DataFrame with specified columns removed.
         """
         print("Number of features in data set:", len(df.columns))
-        # select columns to keep and assign back to dataframe
-        df = df.drop(columns=drop_cols_fi, axis=1, errors="ignore")
+        if drop_cols_fi:
+            remaining = [c for c in df.columns if c not in drop_cols_fi]
+            if len(remaining) == 0:
+                print(
+                    "Warning: dropping all features would leave none; "
+                    "keeping all features."
+                )
+                return df
+            # Drop only when there is something to remove (and avoid the
+            # deprecated columns=+axis combination on newer pandas).
+            df = df.drop(columns=drop_cols_fi, errors="ignore")
         print("All unimportant features dropped.")
         print("Number of features in data set:", len(df.columns))
         if len(df.columns) == 0:

--- a/tests/test_feature_importance_filter.py
+++ b/tests/test_feature_importance_filter.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for feature-importance filter fallback (issue #6)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+import sklearn.utils.metaestimators as _metaestimators
+
+# eli5 0.13 still imports the removed sklearn helper; provide a shim so the
+# package can be imported on newer scikit-learn versions.
+if not hasattr(_metaestimators, "if_delegate_has_method"):
+    from sklearn.utils.metaestimators import available_if
+
+    def if_delegate_has_method(delegate):  # type: ignore[misc]
+        return available_if(lambda self: hasattr(self, delegate))
+
+    _metaestimators.if_delegate_has_method = if_delegate_has_method
+    sys.modules["sklearn.utils.metaestimators"] = _metaestimators
+
+from automotive_feature_engineering.feature_selection import FeatureSelection
+
+
+class TestFeatureImportanceFilterFallback(unittest.TestCase):
+    def test_keeps_features_when_all_below_threshold(self) -> None:
+        """If every feature is below the threshold, keep all instead of emptying."""
+        cols = [f"sig_{i}" for i in range(8)]
+        df_features = pd.DataFrame({c: [0, 1, 0, 1] for c in cols})
+        df_target = pd.DataFrame({"target": [0, 1, 0, 1]})
+        # Near-zero importances for every column (typical of uniform/one-hot CAN signals).
+        fake_importances = [(0.0, c) for c in cols]
+
+        fs = FeatureSelection()
+        with patch.object(
+            FeatureSelection,
+            "calc_globalFeatureImportance",
+            return_value=fake_importances,
+        ):
+            drop_cols = fs.drop_unimportant_features_fit(
+                ".", 0.0009999, df_features, df_target
+            )
+
+        self.assertEqual(drop_cols, [])
+        transformed = fs.drop_unimportant_features_transform(df_features, drop_cols)
+        self.assertEqual(list(transformed.columns), list(df_features.columns))
+
+    def test_still_drops_when_some_features_pass(self) -> None:
+        cols = ["keep_me", "drop_me"]
+        df_features = pd.DataFrame({c: [0, 1, 0, 1] for c in cols})
+        df_target = pd.DataFrame({"target": [0, 1, 0, 1]})
+        fake_importances = [(0.5, "keep_me"), (0.0, "drop_me")]
+
+        fs = FeatureSelection()
+        with patch.object(
+            FeatureSelection,
+            "calc_globalFeatureImportance",
+            return_value=fake_importances,
+        ):
+            drop_cols = fs.drop_unimportant_features_fit(
+                ".", 0.0009999, df_features, df_target
+            )
+
+        self.assertEqual(list(drop_cols), ["drop_me"])
+        transformed = fs.drop_unimportant_features_transform(df_features, drop_cols)
+        self.assertEqual(list(transformed.columns), ["keep_me"])
+
+    def test_transform_does_not_empty_dataframe(self) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        fs = FeatureSelection()
+        # Simulate a bad drop list that would remove every column.
+        out = fs.drop_unimportant_features_transform(df, ["a", "b"])
+        self.assertEqual(list(out.columns), ["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes [#6](https://github.com/mercedes-benz/automotive_feature_engineering/issues/6): when the feature-importance filter would drop every column, keep all features and warn instead of emptying the dataset.
- Same guard in `drop_unimportant_features_transform` if a drop list would leave zero columns.
- Adds focused unit tests for the fallback behavior.

## Test plan
- [x] `PYTHONPATH=src python -m pytest tests/test_feature_importance_filter.py`
- [ ] Confirm CLA is signed (CLA-mbti@mercedes-benz.com) if CLA-assistant requests it


